### PR TITLE
Fix `0.9` branch glam version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glamour"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Strongly typed linear algebra with glam"
 authors = ["Simon Ask Ulsnes <simon@ulsnes.dk>"]
@@ -15,7 +15,7 @@ categories = ["game-development", "mathematics", "graphics", "no-std"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-glam = { version = ">=0.24.1", default-features = false, features = [
+glam = { version = "0.24.1", default-features = false, features = [
     "bytemuck",
     "approx",
 ] }


### PR DESCRIPTION
The breaking change of updating to `glam:0.25` was supposed to be isolated to the `glamour:0.10` line.
However, due to the way the `glam` version was listed in `glamour:0.9.0`, consumers of that version (who still need `glam:0.24`) will be automatically bumped to `glam:0.25` (or any future version of `glam`).

I'm sure what you meant by `>=0.24.1` was rather `>=0.24.1, <0.25.0`, which in cargo can be represented simply as `0.24.1`.

# Notes
* I've based this PR on your `release-0.9.0` branch as I did not see an `0.9` maintenance branch.
  * (I'm not sure how your release process works, but you may wish this to land in a different spot)
* The `main` branch has the same bug, but since there is not yet a `glam:0.25` it is not yet causing any problems.
  * I'm opening a separate PR to future-proof `main`, but I'd appreciate if you would accept this backport and release `0.9.1`, since this is causing immediate problems for `0.9` consumers.