### PR TITLE
Future-proof glam version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-glam = { version = ">=0.25.0", default-features = false, features = [
+glam = { version = "0.25.0", default-features = false, features = [
     "bytemuck",
     "approx",
 ] }


### PR DESCRIPTION
See PR https://github.com/simonask/glamour/pull/44 for a description of the problem itself and how it is affecting `glamour:0.9`

This PR is for future-proofing the `glamour:0.10` line against premature bumps to future semver-incompatible `glam` versions.

Since `glam:0.26` does not exist yet, this is not a pressing issue for `0.10` in the way that it is for `0.9`; as long as a new `glamour:0.10.*` release is created with this fix before `glam:0.26` (or indeed `glam:1.0`) drops, we'll be fine.